### PR TITLE
Upgrade Spring Boot stack

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,6 @@
         <app.environment>production</app.environment>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <tomcat.version>8.5.37</tomcat.version>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -18,12 +18,25 @@
     </dependencies>
 
     <properties>
+        <spring-boot.version>3.3.5</spring-boot.version>
         <java.version>17</java.version>
         <app.environment>production</app.environment>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <tomcat.version>8.5.37</tomcat.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring-boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <repositories>
 <!--
@@ -76,7 +89,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>2.7.7</version>
+                <version>${spring-boot.version}</version>
                 <configuration>
                     <mainClass>com.api.MicroserviceApplication</mainClass>
 <!--                    <skip>true</skip>-->

--- a/retailstore-rest-server/build.gradle
+++ b/retailstore-rest-server/build.gradle
@@ -6,13 +6,8 @@ plugins {
      * Get recent version from
      * https://plugins.gradle.org/plugin/org.springframework.boot
      */
-    id 'org.springframework.boot' version '2.7.10'
+    id 'org.springframework.boot' version '3.3.5'
     id 'name.remal.sonarlint' version '1.5.0'
-}
-
-// did not work => ${springVersion}
-ext {
-    springVersion = '2.7.10'
 }
 
 repositories {
@@ -28,49 +23,40 @@ description = 'retailstore'
 mainClassName = 'com.api.MicroserviceApplication'
 
 dependencies {
-
-    def springVersion = "2.7.10"
-
     implementation project(':retailstore-rest-schema')
 
     implementation group: 'org.projectlombok', name: 'lombok', version: '1.18.22'
     annotationProcessor group: 'org.projectlombok', name: 'lombok', version: '1.18.22'
 
-    implementation group: 'io.github.resilience4j', name: 'resilience4j-spring-boot2', version: '1.7.0'
-    implementation group: 'com.zaxxer', name: 'HikariCP', version: '3.3.1'
+    implementation group: 'io.github.resilience4j', name: 'resilience4j-spring-boot3', version: '2.2.0'
+    implementation group: 'com.zaxxer', name: 'HikariCP'
 
-    implementation group: 'mysql', name: 'mysql-connector-java', version: '8.0.17'
-
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.8.2'
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.8.2'
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-slf4j-impl', version: '2.8.2'
+    implementation group: 'mysql', name: 'mysql-connector-java'
 
     // 2.12.3 does not have @JsonIncludeProperties
-    implementation (group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jdk8', version: '2.13.4') {
+    implementation (group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jdk8') {
         exclude (group: "junit")
     }
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.13.4'
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.13.4'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core'
 
-    implementation group: 'io.projectreactor.netty', name: 'reactor-netty', version: '0.9.6.RELEASE'
+    implementation group: 'io.projectreactor.netty', name: 'reactor-netty'
 
-    def micrometerVersion = '1.10.6'
 //    compile 'io.micrometer:micrometer-registry-atlas:latest.release'
-    implementation group: 'io.micrometer', name: 'micrometer-core', version: micrometerVersion
-    implementation group: 'io.micrometer', name: 'micrometer-registry-prometheus', version: micrometerVersion
+    implementation group: 'io.micrometer', name: 'micrometer-core'
+    implementation group: 'io.micrometer', name: 'micrometer-registry-prometheus'
 //    implementation group: 'io.micrometer', name: 'micrometer-registry-graphite', version: micrometerVersion
 //    implementation group: 'io.micrometer', name: 'micrometer-registry-statsd', version: micrometerVersion
 
-//    implementation group: 'org.springframework.boot', name: 'spring-boot', version: springVersion
-    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-log4j2', version: springVersion
-    implementation(group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: springVersion) {
+    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-log4j2'
+    implementation(group: 'org.springframework.boot', name: 'spring-boot-starter-web') {
         exclude module: "spring-boot-starter-logging"
         exclude module: "logback-classic"
     }
 
-    implementation group: 'org.springframework', name: 'spring-aspects', version: '5.3.19'
+    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-aop'
 
-    implementation(group: 'org.springframework.boot', name: 'spring-boot-starter-actuator', version: springVersion) {
+    implementation(group: 'org.springframework.boot', name: 'spring-boot-starter-actuator') {
         exclude module: "spring-boot-starter-logging"
         exclude module: "logback-classic"
     }
@@ -78,17 +64,17 @@ dependencies {
     /**
      * test deps
      */
-    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.7.2'
-    testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: '5.7.2'
-    testImplementation group: 'org.junit.platform', name: 'junit-platform-launcher', version: '1.8.1'
+    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api'
+    testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine'
+    testImplementation group: 'org.junit.platform', name: 'junit-platform-launcher'
 
 //    testImplementation group: 'pl.pragmatists', name: 'JUnitParams', version: '1.1.1'
 
-    testImplementation (group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: springVersion) {
+    testImplementation (group: 'org.springframework.boot', name: 'spring-boot-starter-test') {
         exclude module: "logback-classic"
         exclude module: "spring-boot-starter-logging"
     }
-    testImplementation group: 'org.springframework.security', name: 'spring-security-test', version: '5.5.1'
+    testImplementation group: 'org.springframework.security', name: 'spring-security-test'
     testImplementation group: 'com.tngtech.java', name: 'junit-dataprovider', version: '1.13.1'
     testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.12.2'
 }

--- a/retailstore-rest-server/pom.xml
+++ b/retailstore-rest-server/pom.xml
@@ -14,10 +14,8 @@
     <properties>
         <start-class>com.api.MicroserviceApplication</start-class>
         <java.version>17</java.version>
-        <spring-boot.version>2.7.10</spring-boot.version>
-        <micrometer-registry.version>1.10.6</micrometer-registry.version>
-        <junit-jupiter.version>5.7.2</junit-jupiter.version>
-        <jackson.version>2.15.0</jackson.version>
+        <spring-boot.version>3.3.5</spring-boot.version>
+        <resilience4j.version>2.2.0</resilience4j.version>
     </properties>
 
     <dependencies>
@@ -36,64 +34,78 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
-            <version>${spring-boot.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-reactor-netty</artifactId>
-            <version>${spring-boot.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-log4j2</artifactId>
         </dependency>
 
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-core</artifactId>
-            <version>${micrometer-registry.version}</version>
         </dependency>
 
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-prometheus</artifactId>
-            <version>${micrometer-registry.version}</version>
         </dependency>
 
         <dependency>
             <groupId>io.github.resilience4j</groupId>
             <artifactId>resilience4j-ratelimiter</artifactId>
-            <version>1.7.0</version>
-        </dependency>
-
-        <dependency>
-            <groupId>io.micrometer</groupId>
-            <artifactId>micrometer-core</artifactId>
-            <version>1.7.0</version>
+            <version>${resilience4j.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>${jackson.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>${jackson.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-spring-boot3</artifactId>
+            <version>${resilience4j.version}</version>
         </dependency>
 
         <!-- test deps -->
@@ -101,32 +113,18 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit-jupiter.version}</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>${junit-jupiter.version}</version>
             <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.junit.platform</groupId>
-            <artifactId>junit-platform-runner</artifactId>
-            <version>1.8.1</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>junit</groupId>
-                    <artifactId>junit</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
-            <version>2.5.3</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -159,7 +157,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>2.7.18</version>
+                <version>${spring-boot.version}</version>
                 <configuration>
                     <mainClass>com.api.MicroserviceApplication</mainClass>
                     <executable>true</executable>

--- a/retailstore-rest-server/pom.xml
+++ b/retailstore-rest-server/pom.xml
@@ -14,7 +14,6 @@
     <properties>
         <start-class>com.api.MicroserviceApplication</start-class>
         <java.version>17</java.version>
-        <spring-boot.version>3.3.5</spring-boot.version>
         <resilience4j.version>2.2.0</resilience4j.version>
     </properties>
 
@@ -29,7 +28,6 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.28</version>
             <scope>provided</scope>
         </dependency>
 
@@ -137,7 +135,6 @@
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
-            <version>2.6.0</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
## Summary
- update Maven build to Spring Boot 3.3.5 with imported BOM and matching plugin versions
- refresh retailstore-rest-server dependencies for Jakarta servlet support, Log4j2 logging, and Resilience4j Spring Boot 3 integration
- point the Gradle wrapper to Gradle 8.10.2 to match the upgraded Spring Boot toolchain

## Testing
- `./gradlew :retailstore-rest-server:test` *(fails: unable to download Gradle distribution due to proxy restrictions)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69265e6223c48322bb0d86d1d97673e1)